### PR TITLE
Docker updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ RUN apt update && apt install -y \
 
 # Install R libraries
 RUN Rscript -e 'install.packages(c("sf", "remotes", "dplyr", "lubridate", "fst", "shiny", "shinyWidgets", "shinyjs", "shinybusy", "htmlwidgets", "leaflet", "leaflet.extras", "leafem", "quantreg", "minpack.lm", "rgdal", "sp", "ggplot2", "grid", "gridExtra", "dplyr", "tidyr", "geometry", "raster", "proj4", "curl"))'
-RUN Rscript -e 'remotes::install_github("bhaskarvk/leaflet.extras", ref = remotes::github_pull("184"))'
+RUN Rscript -e 'remotes::install_github("bhaskarvk/leaflet.extras")'
 RUN Rscript -e 'remotes::install_github("BIO-RSG/oceancolouR")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,5 @@ RUN apt update && apt install -y \
     r-base-dev r-cran-sf r-cran-raster r-cran-rjava
 
 # Install R libraries
-RUN Rscript -e 'install.packages(c("sf", "remotes", "dplyr", "lubridate", "fst", "shiny", "shinyWidgets", "shinyjs", "shinybusy", "htmlwidgets", "leaflet", "leaflet.extras", "leafem", "quantreg", "minpack.lm", "rgdal", "sp", "ggplot2", "grid", "gridExtra", "dplyr", "tidyr", "geometry", "raster", "proj4", "curl"))'
-RUN Rscript -e 'remotes::install_github("bhaskarvk/leaflet.extras")'
+RUN Rscript -e 'install.packages(c("fst", "shiny", "shinyWidgets", "shinyjs", "shinybusy", "leaflet", "stars", "leafem", "leafpm", "quantreg", "minpack.lm", "sp", "ggplot2", "ggpp", "dplyr", "tidyr", "raster", "RCurl", "sf", "fs"))'
 RUN Rscript -e 'remotes::install_github("BIO-RSG/oceancolouR")'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     image: cioosatlantic/phytofit
     command: >
       /bin/sh -c '
-      cd /srv/shiny-server/phytofit && yes | Rscript download_new_datasets.R
+      cd /srv/shiny-server/phytofit && yes | Rscript 00_download_new_datasets.R
       '
     volumes:
       - "./data:/srv/shiny-server/phytofit/data"


### PR DESCRIPTION
Fixed some file references, updated leaflet.extras remote install reference in Dockerfile.

The download new datasets file name has changed since the original dockerfile was authored, so the name has been updated.

The remote install reference for bhaskarvk/leaflet.extras referenced a commit that is no longer valid, that reference has been omitted and that solves the issue.

It is worth noting that this project has been archived and is no longer being updated.  However, release 1.0.0 is still available and works, how well supported this will be in the future remains to be seen.